### PR TITLE
Add AnswerId field to PostBetRequest

### DIFF
--- a/bet.go
+++ b/bet.go
@@ -22,6 +22,7 @@ type PostBetRequest struct {
 	ContractId string   `json:"contractId"`
 	Outcome    string   `json:"outcome"`
 	LimitProb  *float64 `json:"limitProb,omitempty"`
+	AnswerId   string   `json:"answerId,omitempty"`
 }
 
 // GetBetsRequest represents the optional parameters that can be supplied to


### PR DESCRIPTION
## Summary
- Add `AnswerId` field to `PostBetRequest` struct for placing bets on specific answers in multiple-choice markets
- Field uses `omitempty` so it's excluded from JSON when empty (binary market bets)
- Add `TestPostBetWithAnswerId` test verifying serialization with and without the field

Fixes #10

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] New test verifies `answerId` appears in request JSON when set
- [x] New test verifies `answerId` is omitted from request JSON when empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)