### PR TITLE
Fix KellyBet formula: use payout-1 for net odds

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -66,8 +66,13 @@ func KellyBet(prob, payout float64) float64 {
 		return 0.0
 	}
 
+	// Guard against invalid payout (division by zero or negative net odds)
+	if payout <= 1 {
+		return 0.0
+	}
+
 	// Compute the Kelly bet using the formula: f* = p - ((1-p) / b)
-	k := prob - ((1 - prob) / (payout / 2))
+	k := prob - ((1 - prob) / (payout - 1))
 
 	// Round the Kelly bet to 2 decimal places
 	k = math.Round(k*100) / 100

--- a/utils_test.go
+++ b/utils_test.go
@@ -3,14 +3,27 @@ package mango
 import "testing"
 
 func TestKellyBet(t *testing.T) {
-	prob := 0.6
-	payout := 2.0
-	expected := 0.2
+	tests := []struct {
+		name     string
+		prob     float64
+		payout   float64
+		expected float64
+	}{
+		{"standard case", 0.6, 2.0, 0.2},
+		{"higher prob and payout", 0.7, 3.0, 0.55},
+		{"low payout margin", 0.55, 1.5, -0.35},
+		{"break even", 0.5, 2.0, 0.0},
+		{"zero net odds", 0.5, 1.0, 0.0},
+		{"payout less than 1", 0.5, 0.5, 0.0},
+	}
 
-	result := KellyBet(prob, payout)
-
-	if result != expected {
-		t.Errorf("Expected %f, but got %f", expected, result)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := KellyBet(tt.prob, tt.payout)
+			if result != tt.expected {
+				t.Errorf("KellyBet(%v, %v) = %v, want %v", tt.prob, tt.payout, result, tt.expected)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes the Kelly Criterion formula in `KellyBet()` to use `payout - 1` instead of `payout / 2` for calculating net odds from decimal odds
- Adds a guard clause returning 0.0 when `payout <= 1` (prevents division by zero and negative net odds)
- Replaces single test case with table-driven tests covering 6 scenarios including edge cases

## Test plan
- [x] All existing tests continue to pass
- [x] New test cases verify correct formula output for various prob/payout combinations
- [x] Edge cases for `payout <= 1` return 0.0
- [x] `go vet` passes cleanly

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)